### PR TITLE
Fix code scanning alert no. 18: Cross-site scripting

### DIFF
--- a/WebGoat/Content/ReflectedXSS.aspx.cs
+++ b/WebGoat/Content/ReflectedXSS.aspx.cs
@@ -22,10 +22,10 @@ namespace OWASP.WebGoat.NET
 
 		void LoadCity (String city)
 		{
-            DataSet ds = du.GetOffice(city);
-            lblOutput.Text = "Here are the details for our " + city + " Office";
-            dtlView.DataSource = ds.Tables[0];
-            dtlView.DataBind();
+		    DataSet ds = du.GetOffice(city);
+		    lblOutput.Text = "Here are the details for our " + Server.HtmlEncode(city) + " Office";
+		    dtlView.DataSource = ds.Tables[0];
+		    dtlView.DataBind();
 		}
 
         void FixedLoadCity (String city)


### PR DESCRIPTION
Fixes [https://github.com/lu-mao-webjet/ghas-demo-csharp/security/code-scanning/18](https://github.com/lu-mao-webjet/ghas-demo-csharp/security/code-scanning/18)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided input is properly sanitized before being embedded into the HTML content. The best way to fix this issue is to use the `Server.HtmlEncode` method to encode the `city` parameter before it is used in the HTML string. This will prevent any malicious scripts from being executed.

We will modify the `LoadCity` method to use `Server.HtmlEncode` on the `city` parameter, similar to how it is done in the `FixedLoadCity` method. This change will be made in the file `WebGoat/Content/ReflectedXSS.aspx.cs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
